### PR TITLE
Add item and rune tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,11 @@ npm start
 ```
 
 The server exposes a health check at `/health` and provides an SSE endpoint at `/sse` for MCP clients.
+
+## Tools disponibles
+
+Cette instance MCP expose désormais trois outils&nbsp;:
+
+1. **get_champion_stats** – Récupère les statistiques de base d'un champion par son nom.
+2. **get_all_items** – Retourne la liste complète des objets de League of Legends avec leurs statistiques.
+3. **get_all_runes** – Retourne la liste complète des runes disponibles.

--- a/server.js
+++ b/server.js
@@ -88,5 +88,74 @@ export function createMCPLoLServer() {
     }
   );
 
+  server.registerTool(
+    'get_all_items',
+    {
+      description:
+        'Récupère la liste complète des objets de League of Legends avec leurs statistiques.',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const versionsResponse = await axios.get(
+          'https://ddragon.leagueoflegends.com/api/versions.json'
+        );
+        const latestVersion = versionsResponse.data[0];
+        const itemsResponse = await axios.get(
+          `https://ddragon.leagueoflegends.com/cdn/${latestVersion}/data/en_US/item.json`
+        );
+        const items = itemsResponse.data.data;
+        return {
+          content: [{ type: 'text', text: JSON.stringify(items, null, 2) }],
+          structuredContent: items,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Erreur lors de la récupération des objets. Détails: ${error.message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'get_all_runes',
+    {
+      description: 'Récupère la liste complète des runes de League of Legends.',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const versionsResponse = await axios.get(
+          'https://ddragon.leagueoflegends.com/api/versions.json'
+        );
+        const latestVersion = versionsResponse.data[0];
+        const runesResponse = await axios.get(
+          `https://ddragon.leagueoflegends.com/cdn/${latestVersion}/data/en_US/runesReforged.json`
+        );
+        const runes = runesResponse.data;
+        return {
+          content: [{ type: 'text', text: JSON.stringify(runes, null, 2) }],
+          structuredContent: runes,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Erreur lors de la récupération des runes. Détails: ${error.message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
   return server;
 }


### PR DESCRIPTION
## Summary
- add `get_all_items` to list all League of Legends items
- add `get_all_runes` to list all runes
- document available tools in README

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_684ab31b6f40832aa16b496da9e337ef