### PR TITLE
Add offline fallback for items and runes

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -1,0 +1,20 @@
+{
+  "3006": {
+    "name": "Berserker's Greaves",
+    "plaintext": "Attack Speed boots",
+    "tags": ["Boots", "AttackSpeed"],
+    "stats": {"FlatMovementSpeedMod": 45}
+  },
+  "6672": {
+    "name": "Kraken Slayer",
+    "plaintext": "Every third attack deals bonus damage",
+    "tags": ["Damage", "AttackSpeed"],
+    "stats": {"FlatPhysicalDamageMod": 40}
+  },
+  "3031": {
+    "name": "Infinity Edge",
+    "plaintext": "Massive critical strike damage",
+    "tags": ["Damage", "CriticalStrike"],
+    "stats": {"FlatPhysicalDamageMod": 65}
+  }
+}

--- a/data/runes.json
+++ b/data/runes.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": 8100,
+    "key": "Domination",
+    "icon": "perk-images/Styles/7200_Domination.png",
+    "name": "Domination",
+    "slots": [
+      {
+        "runes": [
+          {
+            "id": 8112,
+            "key": "Electrocute",
+            "icon": "perk-images/Styles/Domination/Electrocute/Electrocute.png",
+            "name": "Electrocute",
+            "shortDesc": "Hitting a champion with 3 separate attacks or abilities in 3s deals bonus adaptive damage.",
+            "longDesc": "Hitting a champion with 3 separate attacks or abilities within 3s deals bonus adaptive damage."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": 8300,
+    "key": "Inspiration",
+    "icon": "perk-images/Styles/7203_Whimsy.png",
+    "name": "Inspiration",
+    "slots": []
+  }
+]

--- a/server.js
+++ b/server.js
@@ -110,15 +110,30 @@ export function createMCPLoLServer() {
           structuredContent: items,
         };
       } catch (error) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Erreur lors de la récupération des objets. Détails: ${error.message}`,
-            },
-          ],
-          isError: true,
-        };
+        try {
+          const localData = await import('./data/items.json', {
+            assert: { type: 'json' },
+          });
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(localData.default, null, 2),
+              },
+            ],
+            structuredContent: localData.default,
+          };
+        } catch (e) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Erreur lors de la récupération des objets. Détails: ${error.message}`,
+              },
+            ],
+            isError: true,
+          };
+        }
       }
     }
   );
@@ -144,15 +159,30 @@ export function createMCPLoLServer() {
           structuredContent: runes,
         };
       } catch (error) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Erreur lors de la récupération des runes. Détails: ${error.message}`,
-            },
-          ],
-          isError: true,
-        };
+        try {
+          const localData = await import('./data/runes.json', {
+            assert: { type: 'json' },
+          });
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(localData.default, null, 2),
+              },
+            ],
+            structuredContent: localData.default,
+          };
+        } catch (e) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Erreur lors de la récupération des runes. Détails: ${error.message}`,
+              },
+            ],
+            isError: true,
+          };
+        }
       }
     }
   );


### PR DESCRIPTION
## Summary
- include small JSON datasets for items and runes
- fall back to these datasets when network requests fail

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_684ab7fd3938832a87c3e48a42887327