### PR TITLE
Fix: Correct SyntaxError by removing stray non-null assertion

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,7 +37,7 @@ async function loadChampion(championName) {
   );
   if (!championKey) {
     championKey = Object.keys(cachedChampions).find(
-      (key) => cachedChampions![key].id.toLowerCase() === championName.toLowerCase(),
+      (key) => cachedChampions[key].id.toLowerCase() === championName.toLowerCase(),
     );
   }
   if (championName.toLowerCase() === 'wukong') championKey = 'MonkeyKing';


### PR DESCRIPTION
A previous change to remove TypeScript syntax missed a non-null assertion operator (`!`) in `cachedChampions![key]` within `server.js`. This operator is not valid JavaScript and caused a SyntaxError.

This commit removes the stray `!` to ensure the code is valid JavaScript and can be parsed correctly by Node.js.